### PR TITLE
Renamed callback according to Moodle 3.0 requirements

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -26,7 +26,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-function local_goodbye_extends_navigation(global_navigation $navigation) {
+function local_goodbye_extend_navigation(global_navigation $navigation) {
     global $USER;
 
     if (!isloggedin() || isguestuser() && !is_siteadmin()) {


### PR DESCRIPTION
Hi again.

A small change that prevents a warning from showing, on Moodle 3.0 >

Thanks
Mathias
