### PR TITLE
Used get_string() to display "username" and "password" labels in form

### DIFF
--- a/check_account_form.php
+++ b/check_account_form.php
@@ -44,11 +44,11 @@ class check_account_form extends moodleform {
         }
         $mform->addElement('static', 'farewell', '', get_config('local_goodbye', 'farewell'));
 
-        $mform->addElement('text', 'username', 'username');
+        $mform->addElement('text', 'username', get_string('username'));
         $mform->setType('username', PARAM_TEXT);
         $mform->addRule('username', $strrequired, 'required', null, 'client');
 
-        $mform->addElement('password', 'password', 'password');
+        $mform->addElement('password', 'password', get_string('password'));
         $mform->setType('password', PARAM_TEXT);
         $mform->addRule('password', $strrequired, 'required', null, 'client');
 


### PR DESCRIPTION
Hi.

Made the form labels i18n'ed.
Thanks again, you plugin helps me a lot.

Bonne journée,
Mathias
